### PR TITLE
Make CHANGELOG link absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ func didOpen(with result: ClayResult?) {
 
 # Changelog
 
-See [CHANGELOG](CHANGELOG.md).
+See [CHANGELOG](https://github.com/ClaySolutions/ClaySDK/blob/master/CHANGELOG.md).


### PR DESCRIPTION
Hi guys,

I am proposing this change to fix a bug on the [SALTOKS Mobile SDK](https://saltoks.com/developers/mobile-sdk) page.
To keep the content on the website up to date, I am always rendering this README on the page--so the relative links don't work.